### PR TITLE
Fix Sequel 4 Deprecation Warning about sequel_polymorphic loading

### DIFF
--- a/lib/sequel/plugins/audited.rb
+++ b/lib/sequel/plugins/audited.rb
@@ -1,4 +1,5 @@
 require_relative '../audited'
+require 'sequel/plugins/polymorphic'
 
 class AuditLog < Sequel::Model
   # handle versioning of audited records


### PR DESCRIPTION
Fixes the following deprecation warning from Sequel 4.49: _SEQUEL DEPRECATION WARNING: requiring 'sequel_polymorphic' to load a plugin is deprecated and will be removed in Sequel 5.  Update the polymorphic plugin to be required via 'sequel/plugins/polymorphic'._

Requires `sequel/plugins/polymorphic` in `audited.rb`.